### PR TITLE
Fix rtlsdr_read_async type to match librtlsdr

### DIFF
--- a/lib/baremetal.d.ts
+++ b/lib/baremetal.d.ts
@@ -42,7 +42,7 @@ export declare const librtlsdr: {
     rtlsdr_get_offset_tuning: ffi.ForeignFunction<number, [ref.Pointer<void>]>;
     rtlsdr_reset_buffer: ffi.ForeignFunction<number, [ref.Pointer<void>]>;
     rtlsdr_read_sync: ffi.ForeignFunction<number, [ref.Pointer<void>, ref.Pointer<void>, number, ref.Pointer<number>]>;
-    rtlsdr_read_async: ffi.ForeignFunction<number, [ref.Pointer<void>, ref.Pointer<unknown>, ref.Pointer<unknown>, number, number]>;
+    rtlsdr_read_async: ffi.ForeignFunction<number, [ref.Pointer<void>, unknown, ref.Pointer<unknown>, number, number]>;
     rtlsdr_cancel_async: ffi.ForeignFunction<number, [ref.Pointer<void>]>;
     rtlsdr_set_bias_tee: ffi.ForeignFunction<number, [ref.Pointer<void>, number]>;
 };

--- a/lib/baremetal.js
+++ b/lib/baremetal.js
@@ -56,7 +56,7 @@ exports.librtlsdr = ffi_napi_1.default.Library("librtlsdr", {
     "rtlsdr_get_offset_tuning": ["int", [exports.rtlsdr_devPtr]],
     "rtlsdr_reset_buffer": ["int", [exports.rtlsdr_devPtr]],
     "rtlsdr_read_sync": ["int", [exports.rtlsdr_devPtr, exports.voidPtr, "int", exports.intPtr]],
-    "rtlsdr_read_async": ["int", [exports.rtlsdr_devPtr, "pointer", "void *", "uint32", "uint32"]],
+    "rtlsdr_read_async": ["int", [exports.rtlsdr_devPtr, "void", "void *", "uint32", "uint32"]],
     "rtlsdr_cancel_async": ["int", [exports.rtlsdr_devPtr]],
     "rtlsdr_set_bias_tee": ["int", [exports.rtlsdr_devPtr, "int"]]
 });

--- a/src/baremetal.ts
+++ b/src/baremetal.ts
@@ -53,7 +53,7 @@ export const librtlsdr = ffi.Library("librtlsdr", {
     "rtlsdr_get_offset_tuning": ["int", [rtlsdr_devPtr]],
     "rtlsdr_reset_buffer": ["int", [rtlsdr_devPtr]],
     "rtlsdr_read_sync": ["int", [rtlsdr_devPtr, voidPtr, "int", intPtr]],
-    "rtlsdr_read_async": ["int", [rtlsdr_devPtr, "pointer", "void *", "uint32", "uint32"]],
+    "rtlsdr_read_async": ["int", [rtlsdr_devPtr, "void", "void *", "uint32", "uint32"]],
     "rtlsdr_cancel_async": ["int", [rtlsdr_devPtr]],
     "rtlsdr_set_bias_tee": ["int", [rtlsdr_devPtr, "int"]]
 });


### PR DESCRIPTION
This seems to fix the rtlsdr_cancel_async hanging error on my end